### PR TITLE
Upgrade to Camunda Platform 7.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
     <project.build.resourceEncoding>${encoding}</project.build.resourceEncoding>
     <!-- versions -->
-    <version.camunda>7.12.0</version.camunda>
+    <version.camunda>7.17.0</version.camunda>
     <!-- tests -->
     <version.junit>4.13.1</version.junit>
     <version.assertj>3.4.1</version.assertj>


### PR DESCRIPTION
h2 version 2.1.210 is only supported with Camunda Platform 7.17

Before the build failed in tests with 

```
org.camunda.bpm.engine.ProcessEngineException: Process engine persistence exception
	at org.camunda.bpm.extension.mail.poll.PollMailConnectorProcessTest.pollMailWithTextBody(PollMailConnectorProcessTest.java:50)
Caused by: org.apache.ibatis.exceptions.PersistenceException: 

### Error querying database.  Cause: org.h2.jdbc.JdbcSQLSyntaxErrorException: Werte des Typs "BOOLEAN" und "INTEGER" sind nicht vergleichbar
Values of types "BOOLEAN" and "INTEGER" are not comparable; SQL statement:
...
```

Now `mvn clean package` runs successful again.