### PR TITLE
New feature: Send attachments from process variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add `camunda-bpm-mail-core-1.4.3.jar` to your application server (e.g. `apache-t
 Also make sure that you included the following dependencies:
 
 * [camunda-connect-core](http://mvnrepository.com/artifact/org.camunda.connect/camunda-connect-core/1.0.3) >= 1.0.3
-* [JakartaMail](http://mvnrepository.com/artifact/com.sun.mail/jakarta.mail/1.6.7) >= 1.5.5
+* [JakartaMail](http://mvnrepository.com/artifact/com.sun.mail/jakarta.mail/1.6.7) >= 1.6.7
 * [slf4j-api](http://mvnrepository.com/artifact/org.slf4j/slf4j-api/1.7.21) >= 1.7.32
 
 If you use Wildfly, follow the [special instructions](docs/shared-process-engine-wildfly.md).

--- a/README.md
+++ b/README.md
@@ -70,17 +70,18 @@ See the [connectors user guide](http://docs.camunda.org/manual/latest/user-guide
 
 Connector-Id: mail-send
 
-| Input parameter | Type                           | Required?             |
-|-----------------|--------------------------------|-----------------------|
-| from            | String                         | no (read from config) |
-| fromAlias       | String                         | no (read from config) |
-| to              | String                         | yes                   |
-| cc              | String                         | no                    |
-| bcc             | String                         | no                    |
-| subject         | String                         | yes                   |
-| text            | String                         | no                    |
-| html            | String                         | no                    |
-| fileNames       | List of String (path to files) | yes                   |
+| Input parameter | Type                                   | Required?             |
+|-----------------|----------------------------------------|-----------------------|
+| from            | String                                 | no (read from config) |
+| fromAlias       | String                                 | no (read from config) |
+| to              | String                                 | yes                   |
+| cc              | String                                 | no                    |
+| bcc             | String                                 | no                    |
+| subject         | String                                 | yes                   |
+| text            | String                                 | no                    |
+| html            | String                                 | no                    |
+| fileNames       | List of String (path to files)         | no                    |
+| files           | Map of String to file process variable | no                    |
 
 The text or html body can also be generated from a template (e.g. using FreeMarker). See the [example](examples/pizza#send-a-mail).
 

--- a/docs/shared-process-engine-wildfly.md
+++ b/docs/shared-process-engine-wildfly.md
@@ -23,7 +23,7 @@ Tested with Camunda Version 7.17 running on WildFly Full 26.0.1.Final
 
 2. Create a module for slf4j.api:
 
-    Add a a `module.xml` with the following content into `\server\wildfly-26.0.1.Final\modules\org\slf4j\slf4j-api\main`:
+    Add a `module.xml` with the following content into `\server\wildfly-26.0.1.Final\modules\org\slf4j\slf4j-api\main`:
   
     ```
     <module xmlns="urn:jboss:module:1.0" name="org.slf4j.slf4j-api">
@@ -48,4 +48,4 @@ Tested with Camunda Version 7.17 running on WildFly Full 26.0.1.Final
     <module name="org.camunda.bpm.extension.camunda-bpm-mail-core" services="import" />
     ```
   
-4. An easy way to configure the connection is to copy the `mail-config.properties` into the `\server\wildfly26.0.1.Final\standalone\config` folder and add an environment variable `MAIL_CONFIG` that points to the file. Have a look at the configuration section for further details.
+5. An easy way to configure the connection is to copy the `mail-config.properties` into the `\server\wildfly26.0.1.Final\standalone\config` folder and add an environment variable `MAIL_CONFIG` that points to the file. Have a look at the configuration section for further details.

--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/send/SendMailConnector.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/send/SendMailConnector.java
@@ -147,7 +147,9 @@ public class SendMailConnector extends AbstractConnector<SendMailRequest, EmptyR
   }
 
   protected boolean isTextOnlyMessage(SendMailRequest request) {
-    return request.getHtml() == null && request.getFileNames() == null;
+    return request.getHtml() == null
+        && request.getFileNames() == null
+        && request.getFiles() == null;
   }
 
   protected MailConfiguration getConfiguration() {

--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/send/SendMailConnector.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/send/SendMailConnector.java
@@ -12,8 +12,12 @@
  */
 package org.camunda.bpm.extension.mail.send;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URLConnection;
 import java.util.Date;
+import java.util.Map.Entry;
+import javax.activation.DataHandler;
 import javax.mail.Message;
 import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
@@ -23,6 +27,7 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
+import javax.mail.util.ByteArrayDataSource;
 import org.camunda.bpm.extension.mail.EmptyResponse;
 import org.camunda.bpm.extension.mail.MailConnectorException;
 import org.camunda.bpm.extension.mail.MailContentType;
@@ -122,6 +127,17 @@ public class SendMailConnector extends AbstractConnector<SendMailRequest, EmptyR
         for (String fileName : request.getFileNames()) {
           MimeBodyPart part = new MimeBodyPart();
           part.attachFile(fileName);
+          multiPart.addBodyPart(part);
+        }
+      }
+      if (request.getFiles() != null) {
+        for (Entry<String, ByteArrayInputStream> file : request.getFiles().entrySet()) {
+          ByteArrayDataSource ds =
+              new ByteArrayDataSource(
+                  file.getValue(), URLConnection.guessContentTypeFromName(file.getKey()));
+          MimeBodyPart part = new MimeBodyPart();
+          part.setFileName(file.getKey());
+          part.setDataHandler(new DataHandler(ds));
           multiPart.addBodyPart(part);
         }
       }

--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/send/SendMailRequest.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/send/SendMailRequest.java
@@ -12,8 +12,10 @@
  */
 package org.camunda.bpm.extension.mail.send;
 
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.camunda.bpm.extension.mail.EmptyResponse;
 import org.camunda.bpm.extension.mail.config.MailConfiguration;
 import org.camunda.connect.impl.AbstractConnectorRequest;
@@ -23,22 +25,17 @@ import org.slf4j.LoggerFactory;
 
 public class SendMailRequest extends AbstractConnectorRequest<EmptyResponse> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SendMailRequest.class);
-
   protected static final String PARAM_FROM = "from";
   protected static final String PARAM_FROM_ALIAS = "fromAlias";
-
   protected static final String PARAM_TO = "to";
   protected static final String PARAM_CC = "cc";
   protected static final String PARAM_BCC = "bcc";
-
   protected static final String PARAM_SUBJECT = "subject";
-
   protected static final String PARAM_TEXT = "text";
   protected static final String PARAM_HTML = "html";
-
   protected static final String PARAM_FILE_NAMES = "fileNames";
-
+  protected static final String PARAM_FILES = "files";
+  private static final Logger LOGGER = LoggerFactory.getLogger(SendMailRequest.class);
   protected final MailConfiguration configuration;
 
   public SendMailRequest(Connector<?> connector, MailConfiguration configuration) {
@@ -132,6 +129,15 @@ public class SendMailRequest extends AbstractConnectorRequest<EmptyResponse> {
 
   public SendMailRequest fileNames(String... fileNames) {
     setRequestParameter(PARAM_FILE_NAMES, Arrays.asList(fileNames));
+    return this;
+  }
+
+  public Map<String, ByteArrayInputStream> getFiles() {
+    return getRequestParameter(PARAM_FILES);
+  }
+
+  public SendMailRequest files(Map<String, ByteArrayInputStream> files) {
+    setRequestParameter(PARAM_FILES, files);
     return this;
   }
 

--- a/extension/core/src/test/resources/processes/mail-send-file.bpmn
+++ b/extension/core/src/test/resources/processes/mail-send-file.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="0.7.0-nightly">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0">
   <bpmn:process id="send-mail" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_11cgg2j</bpmn:outgoing>
@@ -21,6 +21,11 @@
                 <camunda:value>${file}</camunda:value>
               </camunda:list>
             </camunda:inputParameter>
+            <camunda:inputParameter name="files">
+              <camunda:map>
+                <camunda:entry key="attachment2.txt">${fileValue}</camunda:entry>
+              </camunda:map>
+            </camunda:inputParameter>
           </camunda:inputOutput>
           <camunda:connectorId>mail-send</camunda:connectorId>
         </camunda:connector>
@@ -34,29 +39,29 @@
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="173" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_11cgg2j_di" bpmnElement="SequenceFlow_11cgg2j">
-        <di:waypoint xsi:type="dc:Point" x="209" y="120" />
-        <di:waypoint xsi:type="dc:Point" x="297" y="120" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="208" y="95" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="EndEvent_1nuk1mt_di" bpmnElement="EndEvent_1nuk1mt">
         <dc:Bounds x="454" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="427" y="138" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_13thl7w_di" bpmnElement="ServiceTask_13thl7w">
+        <dc:Bounds x="297" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_11cgg2j_di" bpmnElement="SequenceFlow_11cgg2j">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="297" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="208" y="95" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_01xeo0u_di" bpmnElement="SequenceFlow_01xeo0u">
-        <di:waypoint xsi:type="dc:Point" x="397" y="120" />
-        <di:waypoint xsi:type="dc:Point" x="454" y="120" />
+        <di:waypoint x="397" y="120" />
+        <di:waypoint x="454" y="120" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="380.5" y="95" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ServiceTask_13thl7w_di" bpmnElement="ServiceTask_13thl7w">
-        <dc:Bounds x="297" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION
## Description
Currently, only sending of files is supported that are present on the file system.

In general, this aligns very well with the story of the plugin. Attachments from a received mail are also saved to the file system.

As of now, storing binary data to a file system is not super due any more.

The first step of a preparation to provide a general configurability would be to provide a way to add process variables as file attachments to an email.

## Additional context
Closes #59 

## Testing your changes
The test SendMailConnectorProcessTest.sendMailWithFileNameAndFiles() tests the behaviour.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
