### PR TITLE
Add option to disable notification service in Spring Boot

### DIFF
--- a/extension/spring-boot/README.md
+++ b/extension/spring-boot/README.md
@@ -27,10 +27,18 @@ To use the notification service, please register Beans of type `Consumer<Mail>` 
 
 ## How to Configure it?
 
+### General Configuration
+
 Configure the plugin via a YAML/Properties file (i.e., the `application.yml`).
 Precede all properties with the prefix `camunda.bpm.plugin.mail`.
 
-The `mail.` prefix that comes with the old bootstrapping strategy will be appended to remain compatible.
+The `mail.` prefix that comes with the old bootstrapping strategy will be appended to remain compatible with Jakarta Mail.
+
+### Special configuration properties
+
+To not use the notification service, please set `camunda.bpm.plugin.mail.notification.enabled=false`. By default, the notification service will be active.
+
+### Example
 
 An Example configuration can look like this
 

--- a/extension/spring-boot/src/main/java/org/camunda/bpm/extension/mail/spring/boot/MailConnectorConfiguration.java
+++ b/extension/spring-boot/src/main/java/org/camunda/bpm/extension/mail/spring/boot/MailConnectorConfiguration.java
@@ -14,6 +14,7 @@ import org.camunda.bpm.extension.mail.service.MailServiceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
@@ -54,6 +55,13 @@ public class MailConnectorConfiguration {
   }
 
   @Bean
+  @ConditionalOnProperty(
+      value = {
+        "camunda.bpm.plugin.mail.notification.enabled",
+        "camunda.bpm.plugin.mail.mail.notification.enabled"
+      },
+      matchIfMissing = true,
+      havingValue = "true")
   public MailNotificationService mailNotificationService(
       MailConfiguration mailConfiguration,
       MailService mailService,

--- a/extension/spring-boot/src/test/java/org/camunda/bpm/extension/mail/spring/boot/ConditionalNotificationServiceTest.java
+++ b/extension/spring-boot/src/test/java/org/camunda/bpm/extension/mail/spring/boot/ConditionalNotificationServiceTest.java
@@ -3,9 +3,11 @@ package org.camunda.bpm.extension.mail.spring.boot;
 import static org.assertj.core.api.Assertions.*;
 
 import org.camunda.bpm.extension.mail.notification.MailNotificationService;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
+@Disabled
 public class ConditionalNotificationServiceTest {
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner().withUserConfiguration(MailConnectorConfiguration.class);

--- a/extension/spring-boot/src/test/java/org/camunda/bpm/extension/mail/spring/boot/ConditionalNotificationServiceTest.java
+++ b/extension/spring-boot/src/test/java/org/camunda/bpm/extension/mail/spring/boot/ConditionalNotificationServiceTest.java
@@ -3,11 +3,9 @@ package org.camunda.bpm.extension.mail.spring.boot;
 import static org.assertj.core.api.Assertions.*;
 
 import org.camunda.bpm.extension.mail.notification.MailNotificationService;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-@Disabled
 public class ConditionalNotificationServiceTest {
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner().withUserConfiguration(MailConnectorConfiguration.class);

--- a/extension/spring-boot/src/test/java/org/camunda/bpm/extension/mail/spring/boot/ConditionalNotificationServiceTest.java
+++ b/extension/spring-boot/src/test/java/org/camunda/bpm/extension/mail/spring/boot/ConditionalNotificationServiceTest.java
@@ -1,0 +1,32 @@
+package org.camunda.bpm.extension.mail.spring.boot;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.camunda.bpm.extension.mail.notification.MailNotificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+public class ConditionalNotificationServiceTest {
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner().withUserConfiguration(MailConnectorConfiguration.class);
+
+  @Test
+  void shouldNotInstantiateNotificationService() {
+    contextRunner
+        .withPropertyValues("camunda.bpm.plugin.mail.notification.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(MailNotificationService.class);
+            });
+  }
+
+  @Test
+  void shouldNotInstantiateNotificationService2() {
+    contextRunner
+        .withPropertyValues("camunda.bpm.plugin.mail.mail.notification.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(MailNotificationService.class);
+            });
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.maven-surefire-plugin}</version>
           <configuration>
-            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <redirectTestOutputToFile>false</redirectTestOutputToFile>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.maven-surefire-plugin}</version>
           <configuration>
-            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+            <redirectTestOutputToFile>true</redirectTestOutputToFile>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Description
This PR adds a configuration option to disable the notification service for the spring boot starter.

## Additional context
Closes #127 

## Testing your changes
There is a unit test that asserts that setting the property to false will prevent a bean of being created.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
