### PR TITLE
fix a bug where an absolute classpath did not work

### DIFF
--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/config/JakartaMailProperties.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/config/JakartaMailProperties.java
@@ -53,7 +53,9 @@ public class JakartaMailProperties {
 
     if (path.startsWith(PROPERTIES_CLASSPATH_PREFIX)) {
       String pathWithoutPrefix = path.substring(PROPERTIES_CLASSPATH_PREFIX.length());
-
+      if (pathWithoutPrefix.startsWith("/")) {
+        pathWithoutPrefix = pathWithoutPrefix.substring(1);
+      }
       LOG.debug("load mail properties from classpath '{}'", pathWithoutPrefix);
 
       return JakartaMailProperties.class.getClassLoader().getResourceAsStream(pathWithoutPrefix);

--- a/extension/core/src/test/java/org/camunda/bpm/extension/mail/config/JakartaMailPropertiesTest.java
+++ b/extension/core/src/test/java/org/camunda/bpm/extension/mail/config/JakartaMailPropertiesTest.java
@@ -1,0 +1,31 @@
+package org.camunda.bpm.extension.mail.config;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class JakartaMailPropertiesTest {
+  @Test
+  public void testLoadPropertiesFromClasspath_absolutePath() throws IOException {
+    try(InputStream in = JakartaMailProperties.getPropertiesAsStream("classpath:/mail-config.properties")){
+      assertThat(in).isNotNull();
+      Properties properties = new Properties();
+      properties.load(in);
+      assertThat(properties.getProperty("mail.smtp.host")).isEqualTo("localhost");
+    }
+  }
+
+  @Test
+  public void testLoadPropertiesFromClasspath_relativePath() throws IOException {
+    try(InputStream in = JakartaMailProperties.getPropertiesAsStream("classpath:mail-config.properties")){
+      assertThat(in).isNotNull();
+      Properties properties = new Properties();
+      properties.load(in);
+      assertThat(properties.getProperty("mail.smtp.host")).isEqualTo("localhost");
+    }
+  }
+}

--- a/extension/core/src/test/java/org/camunda/bpm/extension/mail/config/JakartaMailPropertiesTest.java
+++ b/extension/core/src/test/java/org/camunda/bpm/extension/mail/config/JakartaMailPropertiesTest.java
@@ -1,17 +1,17 @@
 package org.camunda.bpm.extension.mail.config;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-
-import static org.assertj.core.api.Assertions.*;
+import org.junit.Test;
 
 public class JakartaMailPropertiesTest {
   @Test
   public void testLoadPropertiesFromClasspath_absolutePath() throws IOException {
-    try(InputStream in = JakartaMailProperties.getPropertiesAsStream("classpath:/mail-config.properties")){
+    try (InputStream in =
+        JakartaMailProperties.getPropertiesAsStream("classpath:/mail-config.properties")) {
       assertThat(in).isNotNull();
       Properties properties = new Properties();
       properties.load(in);
@@ -21,7 +21,8 @@ public class JakartaMailPropertiesTest {
 
   @Test
   public void testLoadPropertiesFromClasspath_relativePath() throws IOException {
-    try(InputStream in = JakartaMailProperties.getPropertiesAsStream("classpath:mail-config.properties")){
+    try (InputStream in =
+        JakartaMailProperties.getPropertiesAsStream("classpath:mail-config.properties")) {
       assertThat(in).isNotNull();
       Properties properties = new Properties();
       properties.load(in);


### PR DESCRIPTION
## Description
The documentation states that a classpath reference is absolute. Currently, this does not work. This fix re-enables it.

## Additional context
closes #144 

## Testing your changes
There is a new test in place asserting that loading properties from the classpath work with an absolute AND a relative path.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @camunda-community-hub/devrel in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's maintainer.
